### PR TITLE
Graft fix row column names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 .RData
 .Rhistory
-test*

--- a/parse_args.R
+++ b/parse_args.R
@@ -2,8 +2,8 @@
 
 matrix_arg = function(mat) {
   m = as.data.frame(t(as.data.frame(mat$rows)))
-  rownames(m) = if (all(mat$row_names == NULL)) paste('R', 1:length(mat$row_names),sep="") else mat$row_names
-  colnames(m) = if (all(mat$col_names == NULL)) paste('C', 1:length(mat$col_names),sep="") else mat$col_names
+  rownames(m) = if (length(mat$row_names) != length(unique(mat$row_names))) paste('R', 1:length(mat$row_names),sep="") else mat$row_names
+  colnames(m) = if (length(mat$col_names) != length(unique(mat$col_names))) paste('C', 1:length(mat$col_names),sep="") else mat$col_names
   return(m)
 }
 

--- a/run_tests.R
+++ b/run_tests.R
@@ -1,0 +1,13 @@
+library('RUnit')
+
+source('server.R')
+
+test.suite <- defineTestSuite(
+  "rtemis",
+  dirs = file.path("test"),
+  testFileRegexp = '^.*\\.R'
+)
+
+test.result <- runTestSuite(test.suite)
+
+printTextProtocol(test.result)

--- a/test/parse_args.R
+++ b/test/parse_args.R
@@ -1,0 +1,21 @@
+test.parse_matrix = function() {
+  # a normal matrix with col_names and row_names
+  json = '{"matrix":{"col_names":["a", "b", "c"],"row_names":["x","y","z"],"rows":[
+    [ 1, 2, 3], [4, 5, 6], [7, 8, 9 ]
+  ]}}'
+
+  mat = matrix_arg(fromJSON(json)$matrix)
+
+  checkEquals(colnames(mat), c("a", "b", "c"))
+  checkEquals(rownames(mat), c("x", "y", "z"))
+
+  # a matrix with duplicate col_names and row_names
+  json = '{"matrix":{"col_names":["a", "a", "c"],"row_names":[null,null,"z"],"rows":[
+    [ 1, 2, 3], [4, 5, 6], [7, 8, 9 ]
+  ]}}'
+
+  mat = matrix_arg(fromJSON(json)$matrix)
+
+  checkEquals(colnames(mat), c("C1", "C2", "C3"))
+  checkEquals(rownames(mat), c("R1", "R2", "R3"))
+}


### PR DESCRIPTION
When a matrix comes in as JSON input it must be parsed into an R data frame. Previously this was done incorrectly which meant rownames and colnames were being discarded and replaced with R1/R2/R3 C1/C2/C3 etc. This hopefully resolves the issue. I also added tests using RUnit (to run, do R --no-save < run_tests.R).